### PR TITLE
Turn InvoiceNote's subject code into an optional property

### DIFF
--- a/src/BusinessTermsGroup/InvoiceNote.php
+++ b/src/BusinessTermsGroup/InvoiceNote.php
@@ -13,7 +13,7 @@ class InvoiceNote
      * BT-21
      * The subject of the textual note in BT-22.
      */
-    private InvoiceNoteCode $subjectCode;
+    private ?InvoiceNoteCode $subjectCode;
 
     /**
      * BT-22
@@ -21,15 +21,22 @@ class InvoiceNote
      */
     private string $note;
 
-    public function __construct(InvoiceNoteCode $subjectCode, string $note)
+    public function __construct(string $note)
     {
-        $this->subjectCode = $subjectCode;
+        $this->subjectCode = null;
         $this->note = $note;
     }
 
-    public function getSubjectCode(): InvoiceNoteCode
+    public function getSubjectCode(): ?InvoiceNoteCode
     {
         return $this->subjectCode;
+    }
+
+    public function setSubjectCode(?InvoiceNoteCode $subjectCode): self
+    {
+        $this->subjectCode = $subjectCode;
+
+        return $this;
     }
 
     public function getNote(): string

--- a/tests/BusinessRulesIntegrityConstraintsTest.php
+++ b/tests/BusinessRulesIntegrityConstraintsTest.php
@@ -54,8 +54,8 @@ class BusinessRulesIntegrityConstraintsTest extends TestCase
         ))
             ->setBuyerReference("SERVEXEC")
             ->addIncludedNote(
-                new InvoiceNote(InvoiceNoteCode::REASON, "Lorem Ipsum"),
-                new InvoiceNote(InvoiceNoteCode::ADDITIONAL_CONDITIONS, "Lorem Ipsum"),
+                new InvoiceNote("Lorem Ipsum"),
+                new InvoiceNote("Lorem Ipsum"),
             );
     }
 

--- a/tests/XmlGenerationTest.php
+++ b/tests/XmlGenerationTest.php
@@ -54,8 +54,8 @@ class XmlGenerationTest extends TestCase
                 )]
             ))->setBuyerReference("SERVEXEC")
             ->addIncludedNote(
-                new InvoiceNote(InvoiceNoteCode::REASON, "Lorem Ipsum"),
-                new InvoiceNote(InvoiceNoteCode::ADDITIONAL_CONDITIONS, "Lorem Ipsum"),
+                new InvoiceNote("Lorem Ipsum"),
+                new InvoiceNote("Lorem Ipsum"),
             ),
             ProcessControl::BASIC => (new Invoice(
                 new InvoiceIdentifier('34'),
@@ -78,8 +78,8 @@ class XmlGenerationTest extends TestCase
                 )]
             ))->setBuyerReference("SERVEXEC")
             ->addIncludedNote(
-                new InvoiceNote(InvoiceNoteCode::REASON, "Lorem Ipsum"),
-                new InvoiceNote(InvoiceNoteCode::ADDITIONAL_CONDITIONS, "Lorem Ipsum"),
+                new InvoiceNote("Lorem Ipsum"),
+                new InvoiceNote("Lorem Ipsum"),
             ),
         ];
 


### PR DESCRIPTION
EN 16931-1 specifies that the invoice note subject code (BT-21) is an optional data. It should not be required to instantiate an `InvoiceNote`.